### PR TITLE
Null Reference Exception

### DIFF
--- a/MPL/Core/MplPackage.cs
+++ b/MPL/Core/MplPackage.cs
@@ -193,7 +193,9 @@ namespace MPL {
         foreach (string key in installedThemesKeys) {
           using (RegistryKey themeKey = themesKey.OpenSubKey(key)) {
             if (themeKey != null) {
-              themes.Add(new Theme {id = key, name = themeKey.GetValue(null).ToString()});
+              if (themeKey.GetValue(null) is object name) {
+                themes.Add(new Theme {id = key, name = name.ToString()});
+              }
             }
           }
         }

--- a/MPL/Extensions/Intellisense/CompletionCommandHandler.cs
+++ b/MPL/Extensions/Intellisense/CompletionCommandHandler.cs
@@ -122,24 +122,23 @@ namespace MPL.Intellisense {
     }
 
     private bool StartSession() {
-      //the caret must be in a non-projection location 
       SnapshotPoint? caretPoint = _textView.Caret.Position.Point.GetPoint(textBuffer => (!textBuffer.ContentType.IsOfType("projection")), PositionAffinity.Predecessor);
-      if (!caretPoint.HasValue) {
+
+      if (MplPackage.completionSession || !caretPoint.HasValue) {
         return false;
       }
 
       _currentSession = _provider.CompletionBroker.CreateCompletionSession(_textView, caretPoint.Value.Snapshot.CreateTrackingPoint(caretPoint.Value.Position, PointTrackingMode.Positive), true);
 
       if (_currentSession != null) {
-        _currentSession.Dismissed += this.OnSessionDismissed; //subscribe to the Dismissed event on the session 
+        _currentSession.Dismissed += this.OnSessionDismissed;
         _currentSession.Start();
-
 
         MplPackage.completionSession = true;
         return true;
-      } else {
-        return false;
       }
+
+      return false;
     }
 
     private bool Cancel() {

--- a/MPL/source.extension.vsixmanifest
+++ b/MPL/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Matway.MPL.e987cf53-0155-4648-bd5d-91af5f10605f" Version="20.06.29" Language="en-US" Publisher="Matway" />
+        <Identity Id="Matway.MPL.e987cf53-0155-4648-bd5d-91af5f10605f" Version="20.11.21" Language="en-US" Publisher="Matway" />
         <DisplayName>MPL language support</DisplayName>
         <Description xml:space="preserve">MPL language support</Description>
         <Preview>true</Preview>


### PR DESCRIPTION
- It was possible to start several autocompletion sessions, and at the end of them was a nre-error.
- Sometimes, at a theme loading stage was a nre-error.
- If mpl-files were opened outside a mpl-project, then it was possibly leaded to nre-error.